### PR TITLE
[JH] [AM] mark purchased item

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -52,7 +52,10 @@ export function App() {
 							<Home data={lists} setListPath={setListPath} user={user} />
 						}
 					/>
-					<Route path="/list" element={<List data={data} />} />
+					<Route
+						path="/list"
+						element={<List data={data} listPath={listPath} />}
+					/>
 					<Route
 						path="/manage-list"
 						element={<ManageList listPath={listPath} currentUserId={userId} />}

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -7,6 +7,7 @@ import {
 	doc,
 	onSnapshot,
 	updateDoc,
+	increment,
 } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 import { db } from './config';
@@ -212,12 +213,18 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	}
 }
 
-export async function updateItem() {
-	/**
-	 * TODO: Fill this out so that it uses the correct Firestore function
-	 * to update an existing item. You'll need to figure out what arguments
-	 * this function must accept!
-	 */
+export async function updateItem(listPath, itemId) {
+	const docRef = doc(db, listPath, 'items', itemId);
+	try {
+		await updateDoc(docRef, {
+			totalPurchases: increment(1),
+			dateLastPurchased: new Date(),
+		});
+		return { success: true };
+	} catch (e) {
+		console.error('Error updating item. ', e);
+		return { success: false };
+	}
 }
 
 export async function deleteItem() {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -54,7 +54,7 @@ export function ListItem({ item, listPath }) {
 	}
 
 	return (
-		<div>
+		<li>
 			<label htmlFor={name} className="ListItem">
 				<input
 					type="checkbox"
@@ -65,6 +65,6 @@ export function ListItem({ item, listPath }) {
 				/>
 				{name}
 			</label>
-		</div>
+		</li>
 	);
 }

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,4 +1,5 @@
 import './ListItem.css';
+import { updateItem } from '../api';
 import { useState, useEffect } from 'react';
 
 export function ListItem({ name }) {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -18,10 +18,8 @@ export function ListItem({ item, listPath }) {
 			setIsChecked(true);
 		}
 
-		let timeoutId;
-
 		const timeLeft = oneDayInMilliseconds - timeDiff;
-		timeoutId = setTimeout(() => {
+		const timeoutId = setTimeout(() => {
 			setIsChecked(false);
 		}, timeLeft);
 

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -1,4 +1,5 @@
 import './ListItem.css';
+import { useState, useEffect } from 'react';
 
 export function ListItem({ name }) {
 	return <li className="ListItem">{name}</li>;

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -11,16 +11,19 @@ export function ListItem({ item, listPath }) {
 		: 0;
 	const timeDiff = currentDate - lastPurchasedDate; //milliseconds
 	const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
-	const [isChecked, setIsChecked] = useState(timeDiff < oneDayInMilliseconds);
+	const [isChecked, setIsChecked] = useState(false);
 
 	useEffect(() => {
-		let timeoutId;
-		if (isChecked && timeDiff < oneDayInMilliseconds) {
-			const timeLeft = oneDayInMilliseconds - timeDiff;
-			timeoutId = setTimeout(() => {
-				setIsChecked(false);
-			}, timeLeft);
+		if (timeDiff < oneDayInMilliseconds) {
+			setIsChecked(true);
 		}
+
+		let timeoutId;
+
+		const timeLeft = oneDayInMilliseconds - timeDiff;
+		timeoutId = setTimeout(() => {
+			setIsChecked(false);
+		}, timeLeft);
 
 		return () => clearTimeout(timeoutId);
 	}, [isChecked, timeDiff, oneDayInMilliseconds]);
@@ -44,7 +47,7 @@ export function ListItem({ item, listPath }) {
 			if (e.target.checked) {
 				const result = await updateItem(listPath, id);
 				if (result.success) {
-					alert('Item successfully updated');
+					alert('Item purchased');
 				} else {
 					alert('Error: item not updated');
 				}

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -2,6 +2,68 @@ import './ListItem.css';
 import { updateItem } from '../api';
 import { useState, useEffect } from 'react';
 
-export function ListItem({ name }) {
-	return <li className="ListItem">{name}</li>;
+export function ListItem({ item, listPath }) {
+	const { id, name, dateLastPurchased } = item;
+
+	const currentDate = new Date();
+	const lastPurchasedDate = dateLastPurchased
+		? new Date(dateLastPurchased.seconds * 1000)
+		: 0;
+	const timeDiff = currentDate - lastPurchasedDate; //milliseconds
+	const oneDayInMilliseconds = 24 * 60 * 60 * 1000;
+	const [isChecked, setIsChecked] = useState(timeDiff < oneDayInMilliseconds);
+
+	useEffect(() => {
+		let timeoutId;
+		if (isChecked && timeDiff < oneDayInMilliseconds) {
+			const timeLeft = oneDayInMilliseconds - timeDiff;
+			timeoutId = setTimeout(() => {
+				setIsChecked(false);
+			}, timeLeft);
+		}
+
+		return () => clearTimeout(timeoutId);
+	}, [isChecked, timeDiff, oneDayInMilliseconds]);
+
+	async function handleCheck(e) {
+		const timeLeftInMilliseconds = oneDayInMilliseconds - timeDiff;
+		if (isChecked && timeLeftInMilliseconds > 0) {
+			const timeLeftInHours = Math.floor(
+				timeLeftInMilliseconds / (1000 * 60 * 60),
+			);
+			const timeLeftInMinutes = Math.floor(
+				(timeLeftInMilliseconds / (1000 * 60)) % 60,
+			);
+			const alertMessage =
+				timeLeftInHours <= 0
+					? `You can set this item to be purchased again in ${timeLeftInMinutes} minutes`
+					: `You can set this item to be purchased again in ${timeLeftInHours} hours and ${timeLeftInMinutes} minutes`;
+			alert(alertMessage);
+		} else {
+			setIsChecked(e.target.checked);
+			if (e.target.checked) {
+				const result = await updateItem(listPath, id);
+				if (result.success) {
+					alert('Item successfully updated');
+				} else {
+					alert('Error: item not updated');
+				}
+			}
+		}
+	}
+
+	return (
+		<div>
+			<label htmlFor={name} className="ListItem">
+				<input
+					type="checkbox"
+					id={name}
+					onChange={handleCheck}
+					name={name}
+					checked={isChecked}
+				/>
+				{name}
+			</label>
+		</div>
+	);
 }

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -38,7 +38,9 @@ export function List({ data, listPath }) {
 						.filter((d) =>
 							d.name?.toLowerCase().includes(searchString.toLowerCase()),
 						)
-						.map((item, id) => <ListItem key={id} name={item.name} />)
+						.map((item, id) => (
+							<ListItem key={id} item={item} listPath={listPath} />
+						))
 				) : (
 					<h1>You have no items in your list!</h1>
 				)}

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { ListItem } from '../components';
 
-export function List({ data }) {
+export function List({ data, listPath }) {
 	const [searchString, setSearchString] = useState('');
 
 	const handleChange = (e) => {


### PR DESCRIPTION
## Description

This code provides a checkbox next to each list item on the List page so that users can mark their items as purchased. It updates Firestore to increment totalPurchases by 1 and set the dateLastPurchased to the current time. Once the user has checked an item, they cannot uncheck it for the next 24 hours. It will automatically uncheck at the 24 hour mark. If they attempt to uncheck it before then, they will receive an alert notifying them of the time left before they can check it again.

## Related Issue

Closes #9

## Acceptance Criteria
- [x] The `ListItem` component renders a checkbox with a semantic `<label>`.
- [x] Checking off the item in the UI also updates the `dateLastPurchased` and `totalPurchases` properties on the corresponding Firestore document
- [x] The item is shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day). After 24 hours, the item unchecks itself so the user can buy it again.
- [x] The `updateItem` function in `firebase.js` has been filled out, and sends updates to the firestore database when an item is checked

## Updates

### Before

![screen_shot_2024-02-28_at_2 36 55_pm](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/115735046/47afa468-5c0a-41eb-9787-12882837a270)

### After

![Screen Shot 2024-02-28 at 2 42 02 PM](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/115735046/a06a82cc-60a9-43e5-be2f-c58927cdf0c1)
![Screen Shot 2024-02-28 at 2 42 12 PM](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/115735046/04baa000-b1f0-4715-9286-75fa7bec21de)
The following image shows the checkbox after it has been automatically unchecked after manipulating the data in Firestore.
![Screen Shot 2024-02-28 at 2 43 06 PM](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/115735046/70f1a691-26f3-4cf7-8ef4-e4f45252edad)


## Testing Steps / QA Criteria

1. Select a list from the Home page (one that is already populated, or add items before the next step).
2. Navigate to the List page.
3. Check a box next to one of the items.
4. An alert should appear that says "Item purchased"
5. Click on the same checkbox again. You should now see an alert that says "You can set this item to be purchased again in [time remaining]". (It will be a 24 hour countdown).
6. To test that this feature is working correctly, go to Firestore. Locate the item that was checked in your items collection. 
7. Check that the `totalPurchases` field has been incremented by 1 count and that the `dateLastPurchased` field reflects the timestamp that the box was checked at.
8. Manipulate the `dateLastPurchased` field to at least 24 hours prior. Click update.
9. The box should now be unchecked.
