### PR TITLE
[AM] [KD] Prevent Duplicates and Empty Item

### DIFF
--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -203,25 +203,26 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 
 	const itemExistsResult = itemExists(itemName, itemsSnapshot);
 
-	if (itemExists) {
+	if (itemExistsResult) {
 		return { success: false, error: 'This item already exists in the list.' };
-	} else
-		try {
-			const newDoc = await addDoc(listCollectionRef, {
-				dateCreated: new Date(),
-				// NOTE: This is null because the item has just been created.
-				// We'll use updateItem to put a Date here when the item is purchased!
-				dateLastPurchased: null,
-				dateNextPurchased: getFutureDate(daysUntilNextPurchase),
-				name: itemName,
-				totalPurchases: 0,
-			});
+	}
 
-			return { success: true, newDoc };
-		} catch (err) {
-			console.error('Error adding new item:', err);
-			return { success: false };
-		}
+	try {
+		const newDoc = await addDoc(listCollectionRef, {
+			dateCreated: new Date(),
+			// NOTE: This is null because the item has just been created.
+			// We'll use updateItem to put a Date here when the item is purchased!
+			dateLastPurchased: null,
+			dateNextPurchased: getFutureDate(daysUntilNextPurchase),
+			name: itemName,
+			totalPurchases: 0,
+		});
+
+		return { success: true, newDoc };
+	} catch (err) {
+		console.error('Error adding new item:', err);
+		return { success: false };
+	}
 }
 
 /*

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -194,6 +194,11 @@ export async function shareList(listPath, currentUserId, recipientEmail) {
  * @param {number} itemData.daysUntilNextPurchase The number of days until the user thinks they'll need to buy the item again.
  */
 export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
+	// validate if itemName is not empty
+	if (itemName.trim() === '') {
+		return { success: false, error: 'Item cannot be empty.' };
+	}
+
 	const listCollectionRef = collection(db, listPath, 'items');
 	const itemsSnapshot = await getDoc(listCollectionRef);
 	// use doc.data() to get data of the doc, doc.data().name to access each item by name

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -201,19 +201,7 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 	const listCollectionRef = collection(db, listPath, 'items');
 	const itemsSnapshot = await getDocs(listCollectionRef);
 
-	// loop through existing items in Firestore doc,
-	// removing whitespace and non-word chars from itemName and
-	// each existing doc item, and make both lowercase for comparison
-	const itemExists = itemsSnapshot.docs.some((doc) => {
-		const normalizeString = (str) =>
-			str ? str.replace(/[^\w]/g, '').toLowerCase() : '';
-		const unformattedItemName = normalizeString(itemName);
-		const unformattedDocItemName = normalizeString(
-			doc.data() ? doc.data().name : '',
-		);
-
-		return unformattedItemName === unformattedDocItemName;
-	});
+	const itemExistsResult = itemExists(itemName, itemsSnapshot);
 
 	if (itemExists) {
 		return { success: false, error: 'This item already exists in the list.' };

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -236,6 +236,32 @@ export async function addItem(listPath, { itemName, daysUntilNextPurchase }) {
 		}
 }
 
+/*
+ * Helper function for checking if a particular item
+ * already exists inside of user's current list
+ */
+function itemExists(itemName, itemsSnapshot) {
+	// function to remove whitespace and non-word chars from str
+	const normalizeString = (str) =>
+		str ? str.replace(/[^\w]/g, '').toLowerCase() : '';
+
+	// create unformatted, "normalized" version of itemName
+	const unformattedItemName = normalizeString(itemName);
+
+	// loop through existing items in itemsSnapshot,
+	// applying normalizeString to each item and checking
+	// if it matches the unformattedItemName
+	const result = itemsSnapshot.docs.some((doc) => {
+		const unformattedDocItemName = normalizeString(
+			doc.data() ? doc.data().name : '',
+		);
+
+		return unformattedItemName === unformattedDocItemName;
+	});
+
+	return result;
+}
+
 export async function updateItem(listPath, itemId) {
 	const docRef = doc(db, listPath, 'items', itemId);
 	try {

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -2,6 +2,7 @@ import {
 	arrayUnion,
 	addDoc,
 	getDoc,
+	getDocs,
 	setDoc,
 	collection,
 	doc,

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -23,19 +23,16 @@ export function ManageList({ listPath, currentUserId }) {
 	//Enter key also submits the form as long as user is on one of the input field
 	async function handleSubmit(e) {
 		e.preventDefault();
-		// const { value } = e.target;
-		// if (value.trim() === '') {
-		// 	alert('Item name cannot be empty');
-		// 	return;
-		// }
 
 		formData.daysUntilNextPurchase = +formData.daysUntilNextPurchase;
 		let result = await addItem(listPath, formData);
-		if (result.success) {
+		if (result && result.success) {
 			setFormData(INITIAL_DATA);
 			alert('Item saved!');
+		} else if (result && result.error) {
+			alert(result.error);
 		} else {
-			alert('Item not saved to database, please try again');
+			alert('Item cannot be saved to database, please try again.');
 		}
 	}
 

--- a/src/views/ManageList.jsx
+++ b/src/views/ManageList.jsx
@@ -23,6 +23,12 @@ export function ManageList({ listPath, currentUserId }) {
 	//Enter key also submits the form as long as user is on one of the input field
 	async function handleSubmit(e) {
 		e.preventDefault();
+		// const { value } = e.target;
+		// if (value.trim() === '') {
+		// 	alert('Item name cannot be empty');
+		// 	return;
+		// }
+
 		formData.daysUntilNextPurchase = +formData.daysUntilNextPurchase;
 		let result = await addItem(listPath, formData);
 		if (result.success) {


### PR DESCRIPTION
## Description

This prevents user from adding empty items and duplicate items including duplicates with alternate casing, spaces, and non-word characters. We used regex to remove formatting from input and existing items in the list for comparison. User will see alerts if they try to add a duplicate item or an empty item name.

## Related Issue

Closes #10

## Acceptance Criteria

- [x] Show an error message if the user tries to submit an empty item
- [x] Show an error message if the user tries to submit a new item that is _identical_ to an existing name. For instance, if the list contains `apples` and the user adds `apples`.
- [x] Show an error message if the user tries to submit a new item that matches an existing name with punctuation and casing normalized. For instance, if the list contains `apples` and the user adds `aPples` or `apples,` or `a pples`.
- [x] The user’s original input is saved in the database

## Updates

### Before

![Screen Shot 2024-03-06 at 16 49 10](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/dfee9568-6920-44bc-b9ae-1be115b90b54)

### After

![before_1](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/c15f4604-73ab-43e9-bcb2-974aba487fe3)
![before_2](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/51a44a7b-373f-4247-84d0-f7f71e830481)
![before_3](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/37d0f43e-b6a9-4ea8-9c2b-1a413fcb3cb5)
![before_4](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/93ba5526-5e01-4391-9660-95e53efa16c0)
![before_6](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/dfbff257-565e-4462-b38f-bae59f0258a5)
![before_5](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/ccaaca9a-0a10-42c3-bba8-8639022e35fa)
![before_7](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/76ceacc4-a2fb-4c13-adfb-feadc95090a2)


## Testing Steps / QA Criteria

Try adding an item with exact same formatting as existing item. You should receive an alert reading "This item already exists in the list." Try adding a duplicate item using mixed casing, non-word characters (such as '!', '*', or '$'), spaces between letters (e.g. ap ples), or any combination of these. Check if the app prevents the user from adding empty items by hitting submit without anything in the input field and also entering at least one space or more. Check the List page to confirm that no duplicates were added.

Note: Screenshot could not capture cursor inside empty input field indicating spaces with alert reading "Item cannot be empty."