### PR TITLE
[MF] [JH] Estimate Next Purchase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
 		"": {
 			"name": "smart-shopping-list-next",
 			"dependencies": {
+				"@the-collab-lab/shopping-list-utils": "^2.2.0",
 				"firebase": "^10.1.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
@@ -3992,6 +3993,15 @@
 			},
 			"peerDependencies": {
 				"@testing-library/dom": ">=7.21.4"
+			}
+		},
+		"node_modules/@the-collab-lab/shopping-list-utils": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@the-collab-lab/shopping-list-utils/-/shopping-list-utils-2.2.0.tgz",
+			"integrity": "sha512-nEN1z/SEOIWO+8JWIgPDNUkrXmXqNomSh5aiZDNdiaUH/JYqyNeXmEOldtMqAfLicSRiFkapcAIlrUUnPzNaog==",
+			"peerDependencies": {
+				"react": "^18.2.0",
+				"react-dom": "^18.2.0"
 			}
 		},
 		"node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"npm": ">=8.19.0"
 	},
 	"dependencies": {
+		"@the-collab-lab/shopping-list-utils": "^2.2.0",
 		"firebase": "^10.1.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",

--- a/src/api/firebase.js
+++ b/src/api/firebase.js
@@ -219,30 +219,30 @@ export async function updateItem(
 	dateLastPurchased,
 	totalPurchases,
 	dateNextPurchased,
+	dateCreated,
 ) {
+	const dateNextPurchasedJS = dateNextPurchased.toDate();
+	const dateLastPurchasedJS = dateLastPurchased?.toDate();
+	const dateCreatedJS = dateCreated.toDate();
+
 	const docRef = doc(db, listPath, 'items', itemId);
-	const lastPurchaseDate = dateLastPurchased ? dateLastPurchased.toDate() : 0;
+	const lastPurchaseDate = dateLastPurchased
+		? dateLastPurchasedJS
+		: dateCreatedJS;
 	const daysSinceLastPurchase = getDaysBetweenDates(
 		new Date(),
 		lastPurchaseDate,
 	);
 
-	// ** TODO ** //
-	// intial previous estimate can be calculated from dateNextPurchased - dateCreated if totalPurchases is 0
-	// if (dayLastPurchased === null) as a check vs totalPurchases === 0 what would be better?
-	// the mystery is previousEstimate for item that has been purchased.
-	// dateLastPurchased minus dateNextPurchased
-	// there is a chance this would return a negative but we can make the helper function absolute so we dont have to worry about that
-
-	const previousEstimate = dateNextPurchased;
+	const previousEstimate = dateLastPurchased
+		? getDaysBetweenDates(dateNextPurchasedJS, dateLastPurchasedJS)
+		: getDaysBetweenDates(dateNextPurchasedJS, dateCreatedJS);
 
 	const daysUntilNextPurchase = calculateEstimate(
 		previousEstimate,
 		daysSinceLastPurchase,
 		totalPurchases,
 	);
-
-	console.log('daysUntilNextPurchase', daysUntilNextPurchase);
 
 	try {
 		await updateDoc(docRef, {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,7 +3,8 @@ import { updateItem } from '../api';
 import { useState, useEffect } from 'react';
 
 export function ListItem({ item, listPath }) {
-	const { id, name, dateLastPurchased } = item;
+	const { id, name, dateLastPurchased, totalPurchases, dateNextPurchased } =
+		item;
 
 	const currentDate = new Date();
 	const lastPurchasedDate = dateLastPurchased
@@ -43,7 +44,13 @@ export function ListItem({ item, listPath }) {
 		} else {
 			setIsChecked(e.target.checked);
 			if (e.target.checked) {
-				const result = await updateItem(listPath, id);
+				const result = await updateItem(
+					listPath,
+					id,
+					dateLastPurchased,
+					totalPurchases,
+					dateNextPurchased,
+				);
 				if (result.success) {
 					alert('Item purchased');
 				} else {

--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -3,8 +3,14 @@ import { updateItem } from '../api';
 import { useState, useEffect } from 'react';
 
 export function ListItem({ item, listPath }) {
-	const { id, name, dateLastPurchased, totalPurchases, dateNextPurchased } =
-		item;
+	const {
+		id,
+		name,
+		dateLastPurchased,
+		totalPurchases,
+		dateNextPurchased,
+		dateCreated,
+	} = item;
 
 	const currentDate = new Date();
 	const lastPurchasedDate = dateLastPurchased
@@ -50,6 +56,7 @@ export function ListItem({ item, listPath }) {
 					dateLastPurchased,
 					totalPurchases,
 					dateNextPurchased,
+					dateCreated,
 				);
 				if (result.success) {
 					alert('Item purchased');

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -10,3 +10,8 @@ const ONE_DAY_IN_MILLISECONDS = 86400000;
 export function getFutureDate(offset) {
 	return new Date(Date.now() + offset * ONE_DAY_IN_MILLISECONDS);
 }
+
+export function getDaysBetweenDates(date1, date2) {
+	if (!date1 || !date2) return 0;
+	return Math.floor((date1 - date2) / ONE_DAY_IN_MILLISECONDS);
+}

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -13,5 +13,5 @@ export function getFutureDate(offset) {
 
 export function getDaysBetweenDates(date1, date2) {
 	if (!date1 || !date2) return 0;
-	return Math.floor((date1 - date2) / ONE_DAY_IN_MILLISECONDS);
+	return Math.floor(Math.abs(date1 - date2) / ONE_DAY_IN_MILLISECONDS);
 }


### PR DESCRIPTION
## Description

This code updates the item's `dateNextPurchased` property in the `updateItem` API call by using the `calculateEstimate` function and a combination of the utils functions. The updated `dateNextPurchased` will be different for every item depending on the item's purchase history. The new date won't necessarily be at 7 or 14 or 30 day interval from the 'dateLastPurchased' as the new date is a result of `calculateEstimate`'s weighted estimate.

## Related Issue

Closes #11 

## Acceptance Criteria

- [x] When the user purchases an item, the item’s `dateNextPurchased` property is calculated using the `calculateEstimate` function and saved to the Firestore database
  - [x] `dateNextPurchased` is saved as **a date**, not a number
- [x] A `getDaysBetweenDates` function is exported from `utils/dates.js`  and imported into `api/firebase.js`
  - [x] This function takes two JavaScript Dates and return the number of days that have passed between them

## Type of Changes

Use one or more labels to help your team understand the nature of the change(s) you’re proposing. E.g., `bug fix` or `enhancement` are common ones.

## Updates
No UI feature.
### Before
### After


## Testing Steps / QA Criteria

General testing to observe update in `dateNextPurchased`:
1. To test that this feature is working correctly, go to Firestore. Navigate to a specific item in a collection/list. Take note of the current `dateNextPurchased`.
2. Select the same list from the Home page in the app.
3. Navigate to the List page.
4. Check off the chosen item. 
5. `dateNextPurchased` should be updated to a new date in Firestore.

(Previously step 6) Further testing to observe different date ranges in `dateNextPurchased`: 
- Newly added items from today or yesterday with less than 2 purchases: `dateNextPurchased` should be updated to today's date when purchased.
- To observe different result in `dateNextPurchased` beyond today's date: manipulate `dateCreated` before checking off the item OR check off an item that was added to the list a while ago. `dateNextPurchased` should be updated to some date in the future. 


