### PR TITLE
[MF] Adding Router to List Name Buttons on Home Screen

### DIFF
--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import './SingleList.css';
 
 export function SingleList({ name, path, setListPath }) {
@@ -7,7 +8,9 @@ export function SingleList({ name, path, setListPath }) {
 
 	return (
 		<li className="SingleList">
-			<button onClick={handleClick}>{name}</button>
+			<Link to="/list">
+				<button onClick={handleClick}>{name}</button>
+			</Link>
 		</li>
 	);
 }


### PR DESCRIPTION
## Description

This code imports React Router Dom Link component into the SingleList.jsx file. The Link component wraps the button in the single list with the "/list" endpoint. This changes each list item on the Home screen so that now when selecting a list you are routed to that specific list page. There is some lag in waiting for the listPath to return the promise and show the correct items. This could be resolved with some kind of loading spinner in a future issue. You can see that the listPath is already passed to the List component in that the name in the greeting matches the specific List the User selects.


## Related Issue

closes #31 
sub-issue of #14 

## Acceptance Criteria

- [x] Make the lists on home page route to corresponding list items display page

## Type of Changes

Use one or more labels to help your team understand the nature of the change(s) you’re proposing. E.g., `bug fix` or `enhancement` are common ones.

## Updates

### Before

https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/117051341/fe6df370-924c-4797-a611-ef548d77abd9

### After
UI has changed a little with the default styling of <Link> and <Button>

https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/117051341/89e42954-dc52-4c21-9539-6f9024f6ccde

## Testing Steps / QA Criteria

- Confirm you can log into your firebase, if not at test deploy to access domains list in firebase permissions settings.
- On Home page select any list you wish to navigate to.
- You will be routed to that list page and see those items.
- Navigate back to Home page and select another list you wish to visit.
