### PR TITLE
[JH] Display next purchased date for each item

### DIFF
--- a/src/components/ListItem.jsx
+++ b/src/components/ListItem.jsx
@@ -13,6 +13,12 @@ export function ListItem({ item, listPath }) {
 	} = item;
 
 	const currentDate = new Date();
+
+	const nextPurchasedDateArr = new Date(dateNextPurchased.seconds * 1000)
+		.toString()
+		.split(' ');
+	const nextPurchasedDate = nextPurchasedDateArr.slice(0, 4).join(' ');
+
 	const lastPurchasedDate = dateLastPurchased
 		? new Date(dateLastPurchased.seconds * 1000)
 		: 0;
@@ -106,6 +112,7 @@ export function ListItem({ item, listPath }) {
 					X
 				</button>
 			</label>
+			<small>Buy Next: {nextPurchasedDate}</small>
 		</li>
 	);
 }


### PR DESCRIPTION
## Description

This code displays next purchased date for each item in a shopping list. For brevity, next purchased date is currently shown as "Buy Next." The Firestore timestamp is first converted to a JavaScript date object, then formatted  to a more user-friendly version of the "date next purchased" using a combination of string and array methods. 

## Related Issue

Closes #33 
Sub-issue of #14

## Acceptance Criteria

- [x] When an item is shown on the page, a date is displayed using the `dateNextPurchased` property. 

## Type of Changes

Use one or more labels to help your team understand the nature of the change(s) you’re proposing. E.g., `bug fix` or `enhancement` are common ones.

## Updates

### Before
![Screen Shot 2024-03-19 at 1 49 36 PM](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/64502078/3f495b29-5c64-492d-8947-b6ebbea3a1af)

### After
![Screen Shot 2024-03-19 at 1 48 42 PM](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/64502078/3c7d340d-fa49-4445-a70d-a06873bda797)

## Testing Steps / QA Criteria

After sign-in, navigate to a list with items. Each item should have a "Buy Next" date displayed below it. 
