### PR TITLE
[KD] Reduce List Items Label Size

### DIFF
--- a/src/components/ListItem.css
+++ b/src/components/ListItem.css
@@ -1,6 +1,6 @@
 .ListItem {
 	align-items: baseline;
-	display: inline;
+	display: inline-flex;
 	flex-direction: row;
 	font-size: 1.2em;
 	cursor: pointer;

--- a/src/components/ListItem.css
+++ b/src/components/ListItem.css
@@ -1,8 +1,9 @@
 .ListItem {
 	align-items: baseline;
-	display: flex;
+	display: inline;
 	flex-direction: row;
 	font-size: 1.2em;
+	cursor: pointer;
 }
 
 .ListItem-checkbox {

--- a/src/index.css
+++ b/src/index.css
@@ -57,8 +57,19 @@ html {
 body {
 	background-color: var(--color-bg);
 	color: var(--color-text);
-	font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui,
-		helvetica neue, helvetica, Ubuntu, roboto, noto, arial, sans-serif;
+	font-family:
+		-apple-system,
+		BlinkMacSystemFont,
+		avenir next,
+		avenir,
+		segoe ui,
+		helvetica neue,
+		helvetica,
+		Ubuntu,
+		roboto,
+		noto,
+		arial,
+		sans-serif;
 	font-size: 1.8rem;
 	line-height: 1.4;
 	margin: 0;
@@ -75,10 +86,19 @@ code {
 	border-radius: 4px;
 	color: var(--color-text);
 	display: inline-block;
-	font-family: Menlo, Consolas, Monaco, Liberation Mono, Lucida Console,
+	font-family:
+		Menlo,
+		Consolas,
+		Monaco,
+		Liberation Mono,
+		Lucida Console,
 		monospace;
 	font-size: 0.9em;
 	padding: 0.15em 0.15em;
+}
+
+.list-items-section {
+	list-style-type: none;
 }
 
 @media screen and (prefers-color-scheme: light) {

--- a/src/index.css
+++ b/src/index.css
@@ -97,10 +97,6 @@ code {
 	padding: 0.15em 0.15em;
 }
 
-.list-items-section {
-	list-style-type: none;
-}
-
 @media screen and (prefers-color-scheme: light) {
 	code {
 		--color-bg: var(--color-gray-light);

--- a/src/views/List.css
+++ b/src/views/List.css
@@ -1,0 +1,3 @@
+.list-items-section {
+	list-style-type: none;
+}

--- a/src/views/List.css
+++ b/src/views/List.css
@@ -1,3 +1,3 @@
-.list-items-section {
+.List-items-section {
 	list-style-type: none;
 }

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { ListItem } from '../components';
 import { Link } from 'react-router-dom';
 import { comparePurchaseUrgency } from '../api';
+import './List.css';
 
 export function List({ data, listPath }) {
 	const [searchString, setSearchString] = useState('');

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -68,7 +68,7 @@ export function List({ data, listPath }) {
 				</form>
 			)}
 
-			<ul>
+			<ul className="list-items-section">
 				{sortedData && sortedData.length > 0 ? (
 					<>
 						<h5>Overdue</h5>

--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -69,7 +69,7 @@ export function List({ data, listPath }) {
 				</form>
 			)}
 
-			<ul className="list-items-section">
+			<ul className="List-items-section">
 				{sortedData && sortedData.length > 0 ? (
 					<>
 						<h5>Overdue</h5>


### PR DESCRIPTION
## Description

Items on 'List' page often get checked off when user clicks in the blank spaces on the page. This code reduces the size of each list item's label size to prevent accidental ticking of the item checkboxes. The cursor will also change to a hand pointer when hovering over a "checkable" item

## Related Issue

Closes #36
Sub-issue of #14

## Acceptance Criteria

- [x] Reduce size of the item labels to reduce the chance of accidentally checking off items.
- [x] Add indicator to show user when they are hovering over a checkable item on the list.

## Type of Changes

Use one or more labels to help your team understand the nature of the change(s) you’re proposing. E.g., `bug fix` or `enhancement` are common ones.

## Updates

### Before

![before_1](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/0cc2db61-cff9-4c1e-a500-468dbdd2ee7d)

### After

![after_1](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/e2673268-f903-434d-b688-09880984bb39)

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria

1. From home, click on a list that already has items.
2. Hover over the empty space directly to the right of the items. Try clicking. Your cursor should not change and you should not be able to check off any items.
3. Hover over one of the items. Your pointer should change into a hand pointer and the checkbox border should change color indicating the ability to check off the item.  Click to check off the item.
