### PR TITLE
[AM] Bug Fix For listPath

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -15,7 +15,7 @@ export function List({ data, listPath }) {
 		setSearchString('');
 	};
 
-	const listName = listPath.split('/')[1];
+	const listName = listPath?.split('/')[1];
 
 	const filteredData = data.filter((d) =>
 		d.name?.toLowerCase().includes(searchString.toLowerCase()),


### PR DESCRIPTION
## Description

Add optional chaining on listPath (List.jsx L18) to prevent crash.

## Related Issue

Related to bug in #8 

## Updates

### Before

![Screen Shot 2024-03-20 at 10 45 10](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/115735046/e4a3f593-a17a-4c95-ac64-d2e7d120b2f8)

### After

![Screen Shot 2024-03-20 at 10 44 10](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/115735046/abdb2180-9ef6-4995-b011-11ccc9322a88)

## Testing Steps / QA Criteria

1. Sign out
2. Clear local storage (this will be addressed in a different bug fix)
3. Go to List page
4. Page should not crash, and should display 'Welcome to your "" list.'

*Note: future updates should make sure user cannot access this page if a list isn't selected, or ensure page display better reflects current state rather than showing "" list.
