### PR TITLE
Inline external dependencies in Vitest to fix `ERR_UNKNOWN_FILE_EXTENSION`

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -67,5 +67,10 @@ export default defineConfig({
 		globals: true,
 		environment: 'jsdom',
 		setupFiles: './tests/setup.js',
+		server: {
+			// Prevents Vitest from crashing when it
+			// encounters a module that exports CSS.
+			deps: { inline: true },
+		},
 	},
 });


### PR DESCRIPTION
## Description

As it says on the tin! This changes our Vitest config so that it can tolerate modules that export CSS files.

## QA steps
1. Pull down this branch
2. run `npm test`
3. Verify that the tests _do not_ fail.
