### PR TITLE
[KD] Add Footer

### DIFF
--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -38,7 +38,6 @@
 .Nav {
 	background-color: var(--color-bg);
 	border-top: 1px solid var(--color-border);
-	bottom: 0;
 	display: flex;
 	flex-direction: row;
 	padding-bottom: max(env(safe-area-inset-bottom), 1rem);
@@ -70,4 +69,32 @@
 .Nav-link.active {
 	text-decoration-thickness: 0.22em;
 	text-underline-offset: 0.1em;
+}
+
+.Layout-footer {
+	background-color: var(--color-bg);
+	border-top: 1px solid var(--color-border);
+	bottom: 0;
+	display: flex;
+	flex-direction: row;
+	padding-bottom: max(env(safe-area-inset-bottom), 1rem);
+	padding-top: 1rem;
+	place-content: center;
+	position: fixed;
+	width: 100%;
+}
+
+.Layout-footer-attribution {
+	font-size: 1.6rem;
+	text-align: center;
+}
+
+.Layout-footer-link {
+	color: var(--color-text);
+	text-decoration: none;
+	font-weight: 500;
+}
+
+.Layout-footer-link:hover {
+	color: var(--color-accent);
 }

--- a/src/views/Layout.css
+++ b/src/views/Layout.css
@@ -80,7 +80,7 @@
 	padding-bottom: max(env(safe-area-inset-bottom), 1rem);
 	padding-top: 1rem;
 	place-content: center;
-	position: fixed;
+	margin-top: auto;
 	width: 100%;
 }
 

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -37,6 +37,56 @@ export function Layout() {
 						</NavLink>
 					</div>
 				</nav>
+				<footer className="Layout-footer">
+					<p className="Layout-footer-attribution">
+						Created by{' '}
+						<a
+							className="Layout-footer-link"
+							href="#"
+							target="_blank"
+							rel="noreferrer"
+						>
+							Amalya
+						</a>
+						,{' '}
+						<a
+							className="Layout-footer-link"
+							href="#"
+							rel="noreferrer"
+							target="_blank"
+						>
+							Jessica
+						</a>
+						,{' '}
+						<a
+							className="Layout-footer-link"
+							href="#"
+							rel="noreferrer"
+							target="_blank"
+						>
+							Karen
+						</a>
+						, &{' '}
+						<a
+							className="Layout-footer-link"
+							href="#"
+							rel="noreferrer"
+							target="_blank"
+						>
+							Marty
+						</a>{' '}
+						(aka the Box Makers) in partnership with{' '}
+						<a
+							className="Layout-footer-link"
+							href="https://the-collab-lab.codes/"
+							rel="noreferrer"
+							target="_blank"
+						>
+							The Collab Lab
+						</a>
+						.
+					</p>
+				</footer>
 			</div>
 		</>
 	);

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -39,7 +39,11 @@ export function Layout() {
 				</nav>
 				<footer className="Layout-footer">
 					<p className="Layout-footer-attribution">
-						Created by{' '}
+						Crafted with care{' '}
+						<span role="img" aria-label="heart">
+							❤️
+						</span>
+						by{' '}
 						<a
 							className="Layout-footer-link"
 							href="#"
@@ -75,7 +79,7 @@ export function Layout() {
 						>
 							Marty
 						</a>{' '}
-						(aka the Box Makers) in partnership with{' '}
+						in partnership with{' '}
 						<a
 							className="Layout-footer-link"
 							href="https://the-collab-lab.codes/"

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -41,7 +41,7 @@ export function Layout() {
 					<p className="Layout-footer-attribution">
 						Crafted with care{' '}
 						<span role="img" aria-label="heart">
-							❤️
+							❤️{' '}
 						</span>
 						by{' '}
 						<a

--- a/src/views/Layout.jsx
+++ b/src/views/Layout.jsx
@@ -46,7 +46,7 @@ export function Layout() {
 						by{' '}
 						<a
 							className="Layout-footer-link"
-							href="#"
+							href="https://github.com/amalyam"
 							target="_blank"
 							rel="noreferrer"
 						>
@@ -55,7 +55,7 @@ export function Layout() {
 						,{' '}
 						<a
 							className="Layout-footer-link"
-							href="#"
+							href="https://github.com/hsiangj"
 							rel="noreferrer"
 							target="_blank"
 						>
@@ -64,7 +64,7 @@ export function Layout() {
 						,{' '}
 						<a
 							className="Layout-footer-link"
-							href="#"
+							href="https://github.com/piecanoe"
 							rel="noreferrer"
 							target="_blank"
 						>
@@ -73,7 +73,7 @@ export function Layout() {
 						, &{' '}
 						<a
 							className="Layout-footer-link"
-							href="#"
+							href="https://github.com/krsnamara"
 							rel="noreferrer"
 							target="_blank"
 						>


### PR DESCRIPTION
## Description

This code adds a footer to the bottom of the site that is visible from every page. It also includes an attribution that links to each contributor's GitHub account.

Note: The Navbar has been moved to the top of the page to clear space for the footer.

## Related Issue
Closes #49
Sub-issue of #14

## Acceptance Criteria
- [x] Make a footer that is visible on every page of the site
- [x] Link to each creator's GitHub profile

## Type of Changes

Use one or more labels to help your team understand the nature of the change(s) you’re proposing. E.g., `bug fix` or `enhancement` are common ones.

## Updates

### Before

![before_1](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/67a2c864-f2f5-4229-ab11-7ea62a896834)

### After

![after_1](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/9a7f8055-b46b-4e61-b9eb-3964859a93c4)

Footer is not sticky:

https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/ce984a0d-d7da-49eb-8f28-e3087301463e

Footer text stays center-aligned even on screens with small width:
![after_3](https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/8cd02844-745e-4727-acdd-692bb1b594f6)


## Testing Steps / QA Criteria

1.  On Home, make sure you can see the footer at the bottom of the page
2.  Navigate to the List page and shrink your window size so you must scroll to see the full page. Scroll down to the bottom of the page to see the footer.
3. Shrink the window width to see that the attribution text stays center-aligned even as it wraps to the next line.