### PR TITLE
[JH] Bug fix for items search bar

### DIFF
--- a/src/views/List.jsx
+++ b/src/views/List.jsx
@@ -226,7 +226,7 @@ export function List({
 					</div>
 				</Dialog>
 				<br />
-				{sortedData && sortedData.length > 0 && (
+				{data && data.length > 0 && (
 					<form>
 						<label htmlFor="searchString">
 							Search:
@@ -243,7 +243,7 @@ export function List({
 				)}
 
 				<ul className="List-items-section">
-					{sortedData && sortedData.length > 0 ? (
+					{data && data.length > 0 ? (
 						<>
 							<h5>Overdue</h5>
 							{overdue.map((item) => (


### PR DESCRIPTION
## Description

This code ensures the search bar remains on the page even if the item the user searches for doesn't exist or if the spelling is incorrect. Previously the search bar would disappear and the list items section would render 'You have no items in your list' instead of empty urgency categories. 

## Related Issue
Closes #60 
Sub-issue of #14 
Related to PR #29 

## Acceptance Criteria

- [x] Search bar should remain on the page and user sees urgency category headings when an item is not found. 

## Type of Changes

Use one or more labels to help your team understand the nature of the change(s) you’re proposing. E.g., `bug fix` or `enhancement` are common ones.

## Updates

### Before
<img width="1233" alt="Screen Shot 2024-03-26 at 10 57 58 AM" src="https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/64502078/bd4b2c0f-8daa-4513-826c-58be4f70257b">

I typed in 'eef' instead of 'eel' - the search bar disappears and the page says 'You have no items in your list.'
<img width="1234" alt="Screen Shot 2024-03-26 at 10 58 58 AM" src="https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/64502078/9440725e-a641-4509-a078-ba6477e1b4e1">


### After

<img width="1237" alt="Screen Shot 2024-03-26 at 10 50 13 AM" src="https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/64502078/64ee0345-e791-43bb-adb0-cbb0dff05bb6">

## Testing Steps / QA Criteria

1. Navigate to /list page
2. Select a list with items
3. Search for an item that's not on the list or misspell the word
4. Both the search bar and urgency category headings should remain on the page

