### PR TITLE
[KD] Change the copy on 'About' Page

### DIFF
--- a/src/views/About.jsx
+++ b/src/views/About.jsx
@@ -1,6 +1,14 @@
 import './About.css';
 
 export function About() {
+	function Emoji({ children, label }) {
+		return (
+			<span role="img" aria-label={label}>
+				{children}
+			</span>
+		);
+	}
+
 	return (
 		<>
 			<main className="About-main">
@@ -12,9 +20,7 @@ export function About() {
 						<p>
 							Aisle Be There to level up your organization game! Create
 							specialized lists for all your kneads!{' '}
-							<span role="img" aria-label="bread">
-								🍞{' '}
-							</span>
+							<Emoji label="bread">🍞</Emoji>
 						</p>
 					</div>
 				</section>
@@ -25,10 +31,7 @@ export function About() {
 						<p>
 							Inside your list, tap the big 'Add' button to add a new item.
 							Aisle Be There for you, asking when you might need to restock your
-							aisle-ments!{' '}
-							<span role="img" aria-label="coffee">
-								☕{' '}
-							</span>
+							aisle-ments! <Emoji label="coffee">☕</Emoji>
 						</p>
 					</div>
 				</section>
@@ -40,9 +43,7 @@ export function About() {
 							As you check items off your list, you're not just staying
 							organized, you're sharing your shopping habits. Aisle Be There to
 							ensuring smoother, more efficient future trips!{' '}
-							<span role="img" aria-label="purple-checkmark">
-								☑️{' '}
-							</span>
+							<Emoji label="purple-checkmark">☑️</Emoji>
 						</p>
 					</div>
 				</section>
@@ -53,10 +54,7 @@ export function About() {
 						<p>
 							The more you use the app, the more Aisle get to know you! Aisle Be
 							There to prioritize items for your next shopping trip based on
-							your buying history.{' '}
-							<span role="img" aria-label="calendar">
-								📆{' '}
-							</span>
+							your buying history. <Emoji label="calendar">📆</Emoji>
 						</p>
 					</div>
 				</section>
@@ -66,10 +64,7 @@ export function About() {
 						<h2>Aisle Be your community</h2>
 						<p>
 							When you share your lists, your friends and family can collaborate
-							and be there for you, too!{' '}
-							<span role="img" aria-label="purple-heart">
-								💜{' '}
-							</span>
+							and be there for you, too! <Emoji label="purple-heart">💜</Emoji>
 						</p>
 					</div>
 				</section>

--- a/src/views/About.jsx
+++ b/src/views/About.jsx
@@ -8,53 +8,68 @@ export function About() {
 				<section className="About-section">
 					<img width="250px" alt="phone screenshot" src="../img/phone.png" />
 					<div className="About-section-text">
-						<h2>Make some lists</h2>
+						<h2>Lending a list-ening ear</h2>
 						<p>
-							Level up your organization game by creating specialized lists for
-							all your needs.
+							Aisle Be There to level up your organization game! Create
+							specialized lists for all your kneads!{' '}
+							<span role="img" aria-label="bread">
+								🍞{' '}
+							</span>
 						</p>
 					</div>
 				</section>
 				<section className="About-section">
 					<img width="250px" alt="phone screenshot" src="../img/phone.png" />
 					<div className="About-section-text">
-						<h2>Add some items</h2>
+						<h2>Before you go down the Aisle</h2>
 						<p>
-							Inside your list, simply tap the big '+' button to add a new item.
-							Box Makers will ask you when you might need to buy the item again.
+							Inside your list, tap the big 'Add' button to add a new item.
+							Aisle Be There for you, asking when you might need to restock your
+							aisle-ments!{' '}
+							<span role="img" aria-label="coffee">
+								☕{' '}
+							</span>
 						</p>
 					</div>
 				</section>
 				<section className="About-section">
 					<img width="250px" alt="phone screenshot" src="../img/phone.png" />
 					<div className="About-section-text">
-						<h2>Check items off as you shop</h2>
+						<h2>Aisle check on you</h2>
 						<p>
-							As you purchase items, mark them off your list. By doing so,
-							you're not just staying organized, but you're also teaching Box
-							Makers your shopping habits, making future trips even more
-							streamlined and efficient.
+							As you check items off your list, you're not just staying
+							organized, you're sharing your shopping habits. Aisle Be There to
+							ensuring smoother, more efficient future trips!{' '}
+							<span role="img" aria-label="purple-checkmark">
+								☑️{' '}
+							</span>
 						</p>
 					</div>
 				</section>
 				<section className="About-section">
 					<img width="250px" alt="phone screenshot" src="../img/phone.png" />
 					<div className="About-section-text">
-						<h2>Box Makers predicts when you'll need the item again</h2>
+						<h2>Aisle Be There to guide you</h2>
 						<p>
-							The more you use Box Makers, the smarter it gets! Box Makers will
-							help you prioritize items for your next shopping trip using your
-							buying history.
+							The more you use the app, the more Aisle get to know you! Aisle Be
+							There to prioritize items for your next shopping trip based on
+							your buying history.{' '}
+							<span role="img" aria-label="calendar">
+								📆{' '}
+							</span>
 						</p>
 					</div>
 				</section>
 				<section className="About-section">
 					<img width="250px" alt="phone screenshot" src="../img/phone.png" />
 					<div className="About-section-text">
-						<h2>Share lists with family and friends</h2>
+						<h2>Aisle Be your community</h2>
 						<p>
-							When you share your lists, your friends and family can add and
-							contribute to your list!
+							When you share your lists, your friends and family can collaborate
+							and be there for you, too!{' '}
+							<span role="img" aria-label="purple-heart">
+								💜{' '}
+							</span>
 						</p>
 					</div>
 				</section>


### PR DESCRIPTION
## Description

Previously, we used "Box Makers" as the placeholder name in the copy on the About page. Since then, we've decided that "Aisle Be There" is the official name of the application. This code swaps out occurrences of the placeholder name for the official name. 

Note: I also changed the copy on the page to include more puns.  Very open to changing this back to the original copy if we want to keep a more serious tone. Also open to any other copy changes.

## Related Issue

Closes #59
Sub-issue of #12

## Acceptance Criteria

- [x] Switch out all occurrences of 'Box Makers' on About page for 'Aisle Be There'.

## Type of Changes

Use one or more labels to help your team understand the nature of the change(s) you’re proposing. E.g., `bug fix` or `enhancement` are common ones.

## Updates

### Before


https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/d720a005-b3e4-4fc9-96eb-c909b5bfece3



### After


https://github.com/the-collab-lab/tcl-69-smart-shopping-list/assets/122697843/e4c0efba-cca6-4c49-a99a-38002d1305de



## Testing Steps / QA Criteria

Navigate to 'About' page. Read through the copy on the page to see that there are no occurrences of "Box Makers".
