### PR TITLE
[JH] Update Link location in SingleList

### DIFF
--- a/src/components/SingleList.jsx
+++ b/src/components/SingleList.jsx
@@ -29,7 +29,7 @@ export function SingleList({ name, path, setListPath }) {
 
 	return (
 		<li className="SingleList">
-			<Link to="/list">
+			<Link to="/manage-list">
 				<button onClick={handleClick}>{name}</button>
 				<button
 					type="button"


### PR DESCRIPTION
## Description

This code updates the `Link to= ` location in SingleList.jsx from "/list" to "/manage-list". By clicking on a list, the user will be redirected to the manage list page. Viewing of the list items is dependent on PR#78.

The manage list page was previously deactivated as both lists and list items were rearranged to be on the same page at "/list". The list items are now being separated into its own component and will be rendered at "/manage-list", hence the location update in this PR.

## Related Issue

Original issue #31 
Sub-issue of #14 
The UI of the manage list page is dependent on #78 

## Acceptance Criteria

- [x] Update `Link` location to /manage-list

## Type of Changes

Use one or more labels to help your team understand the nature of the change(s) you’re proposing. E.g., `bug fix` or `enhancement` are common ones.

## Updates

### Before
n/a

### After
n/a


## Testing Steps / QA Criteria

After signing in, navigate to the List page and select a list. You should be redirected to the /manage-list page. 
